### PR TITLE
[TECH-956] feature/tech-956-eslint-action-exclude-deleted-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,36 @@
-# JavaScript Action Template
+# Glidian `action-eslint`
 
-This template offers an easy way to get started writing a javascript action with TypeScript compile time support, unit testing with Jest and using the GitHub Actions Toolkit.
+This repo contains an updated github action that runs eslint on pull request
+files. It is based off of [eslint-action](https://github.com/tinovyatkin/action-eslint).
+ga
+If you need to update the action, create a PR off of this branch
+[release/v.1.0.x](https://github.com/glidian/action-eslint/tree/release/v1.0.x).
+Once the PR is merged, please update the action in [Glidian](https://github.com/ryromano/Glidian),
+to use the new version of the action.
 
-## Getting Started
+## To reference a new version of this action:
 
-See the walkthrough located [here](https://github.com/actions/toolkit/blob/master/docs/javascript-action.md).
+Update the [PR Workflow](https://github.com/ryromano/Glidian/blob/master/.github/workflows/pull-requests.yml)
+to use the new version.
 
-In addition to walking your through how to create an action, it also provides strategies for versioning, releasing and referencing your actions.
+You can reference the new workflow in a number of ways:
+
+```yaml
+# using a commit sha
+ - uses: glidian/action-eslint@8716584
+        with:
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          check-name: eslint
+
+# using a branch name
+ - uses: glidian/action-eslint@release/v.1.0.x
+        with:
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          check-name: eslint
+
+# using a release version
+ - uses: glidian/action-eslint@v.1.0.2
+        with:
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          check-name: eslint
+```


### PR DESCRIPTION
Just a reminder: github's graphql api interface does not return information about file status. This uses the REST interface to get that info. I kept the gql call here because it does a nice job of gathering nodes for a specific Github resource, specifically the last commit.